### PR TITLE
chore: handle errors and allow overwrite

### DIFF
--- a/fs/azblob/blob_file.py
+++ b/fs/azblob/blob_file.py
@@ -20,7 +20,8 @@ class BlobFile(io.RawIOBase):
 
     def flush(self) -> None:
         if self.writable():
-            self.writer.commit()
+            with blobfs_errors(self.client.blob_name):
+                self.writer.commit()
 
     def readable(self) -> bool:
         return self.mode.reading
@@ -88,7 +89,7 @@ class BlobWriter:
         self.buf.extend(data)
 
     def commit(self):
-        self.client.upload_blob(bytes(self.buf))
+        self.client.upload_blob(bytes(self.buf), overwrite=True)
 
 
 class BlobStreamReader:

--- a/tests/test_blob_fs.py
+++ b/tests/test_blob_fs.py
@@ -212,6 +212,13 @@ class TestUpload:
         with new_file(bfs_rw, b"") as fname:
             assert fname in bfs_rw.listdir(".")
 
+    def test_upload_overwrite(self, bfs_rw):
+        fname = "duplicate.txt"
+        bfs_rw.upload(fname, io.BytesIO(b"foo"))
+        bfs_rw.upload(fname, io.BytesIO(b"bar"))
+        assert b"bar" == bfs_rw.getbytes(fname)
+        bfs_rw.remove(fname)
+
     @pytest.mark.skip
     def test_upload_large_file(self, bfs_rw):
         # creates 95 MB file


### PR DESCRIPTION
### Purpose
The pyfilesystem [documentation](https://docs.pyfilesystem.org/en/latest/reference/base.html#fs.base.FS.upload) says that an existing file should be overwritten by an upload, so this change is to be consistent with that.

### What the code is doing
Pass the `overwrite` parameter to the `upload_blob` method from the azure sdk and add a test to ensure uploading the same file twice is successful. Also wrap the upload with our error handler, just in case.

### Testing
new unit test, which fails prior to the code change

### Time estimate
5 min
