### PR TITLE
Fix a lot of things based on the base test suite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Publish Python 🐍 package 📦 to PyPI and TestPyPI
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  release:
+    name: Publish python package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: python -m pip install --upgrade build
+      - run: python -m build
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@
 
 # fs-azureblob
 
+## Installation
+
+The package can be installed via pip:
+```
+pip install git+https://github.com/Breakthrough-Energy/fs-azureblob
+```
+
+Or by cloning the repository and installing directly:
+```
+git clone https://github.com/Breakthrough-Energy/fs-azureblob
+cd fs-azureblob
+pip install .
+```
+Either approach will also install the core `fs` package if it's not already installed.
 
 ## Usage
 
@@ -37,6 +51,18 @@ using the following arguments:
 - `account_name`: the name of the storage account
 - `container`: the blob container
 - `account_key`: optional, but required for write operations or depending on the storage account access policies
+
+## Note
+Since blob storage uses a flat namespace (directories don't really exist), we create a
+placeholder file to represent them, always named `.fs_azblob`. This is an empty blob
+which is created for new directories, removed when a directory is removed, and omitted
+from `listdir` results, so should be transparent to users. To use this package on a new
+blob storage container, nothing needs to be done. For usage on an existing container,
+one should create this structure using the azure portal, sdk, or preferred tool, to
+ensure this package will function as expected.
+
+Additionally, this package is intended to operate on "block blobs". Other blob types
+include page blobs and append blobs. The package has not been tested on these types.
 
 
 ## See also

--- a/fs/azblob/blob_file.py
+++ b/fs/azblob/blob_file.py
@@ -35,7 +35,7 @@ class BlobFile(io.IOBase):
 
     def close(self):
         if self.mode.writing:
-            self.seek(os.SEEK_SET)
+            self.seek(0)
             self.blob.upload_blob(self.raw, overwrite=True)
         self._f.close()
 

--- a/fs/azblob/blob_file.py
+++ b/fs/azblob/blob_file.py
@@ -14,12 +14,12 @@ class BlobFile(io.IOBase):
         return proxy
 
     def __repr__(self):
-        return f"BlobFile({self.blob.blob_name}, {self._mode})"
+        return f"BlobFile({self.blob.blob_name}, {self.mode})"
 
     def __init__(self, f, blob, mode):
         self._f = f
         self.blob = blob
-        self._mode = mode
+        self.mode = mode
 
     def __enter__(self):
         return self
@@ -32,7 +32,7 @@ class BlobFile(io.IOBase):
         return self._f
 
     def close(self):
-        if self._mode.writing:
+        if self.mode.writing:
             self.seek(os.SEEK_SET)
             self.blob.upload_blob(self.raw, overwrite=True)
         self._f.close()
@@ -48,7 +48,7 @@ class BlobFile(io.IOBase):
         return self._f.flush()
 
     def readable(self):
-        return self._mode.reading
+        return self.mode.reading
 
     def readline(self, limit=-1):
         return self._f.readline(limit)
@@ -66,13 +66,13 @@ class BlobFile(io.IOBase):
         return self._f.tell()
 
     def writable(self):
-        return self._mode.writing
+        return self.mode.writing
 
     def writelines(self, lines):
         return self._f.writelines(lines)
 
     def read(self, n=-1):
-        if not self._mode.reading:
+        if not self.mode.reading:
             raise OSError("not open for reading")
         return self._f.read(n)
 
@@ -83,7 +83,7 @@ class BlobFile(io.IOBase):
         return self._f.readinto(b)
 
     def write(self, b):
-        if not self._mode.writing:
+        if not self.mode.writing:
             raise OSError("not open for writing")
         self._f.write(b)
         return len(b)

--- a/fs/azblob/blob_file.py
+++ b/fs/azblob/blob_file.py
@@ -2,6 +2,8 @@ import io
 import os
 import tempfile
 
+from fs.mode import Mode
+
 
 class BlobFile(io.IOBase):
     """Proxy for a blob file."""
@@ -19,7 +21,7 @@ class BlobFile(io.IOBase):
     def __init__(self, f, blob, mode):
         self._f = f
         self.blob = blob
-        self.mode = mode
+        self.mode = Mode(mode)
 
     def __enter__(self):
         return self

--- a/fs/azblob/blob_file.py
+++ b/fs/azblob/blob_file.py
@@ -1,4 +1,3 @@
-import array
 import io
 import typing
 from typing import Iterator, Optional
@@ -63,12 +62,6 @@ class BlobFile(io.RawIOBase):
         if size is None or size < 0:
             size = -1
         return self.reader.readline(size)
-
-    def writelines(self, lines) -> None:
-        for line in lines:
-            if isinstance(line, array.array):
-                line = line.tobytes()
-            self.writer.write(line + b"\n")
 
     def __next__(self) -> bytes:
         line = self.readline()

--- a/fs/azblob/blob_file.py
+++ b/fs/azblob/blob_file.py
@@ -1,6 +1,7 @@
 import io
 import os
 import tempfile
+from typing import Optional
 
 from fs.mode import Mode
 
@@ -16,11 +17,11 @@ class BlobFile(io.IOBase):
         return proxy
 
     def __repr__(self):
-        return f"BlobFile({self.blob.blob_name}, {self.mode})"
+        return f"BlobFile({self._blob.blob_name}, {self.mode})"
 
     def __init__(self, f, blob, mode):
         self._f = f
-        self.blob = blob
+        self._blob = blob
         self.mode = Mode(mode)
 
     def __enter__(self):
@@ -33,70 +34,70 @@ class BlobFile(io.IOBase):
     def raw(self):
         return self._f
 
-    def close(self):
+    def close(self) -> None:
         if self.mode.writing:
             self.seek(0)
-            self.blob.upload_blob(self.raw, overwrite=True)
+            self._blob.upload_blob(self.raw, overwrite=True)
         self._f.close()
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         return self._f.closed
 
-    def fileno(self):
+    def fileno(self) -> int:
         return self._f.fileno()
 
-    def flush(self):
+    def flush(self) -> None:
         return self._f.flush()
 
-    def readable(self):
+    def readable(self) -> bool:
         return self.mode.reading
 
-    def readline(self, limit=-1):
+    def readline(self, limit: Optional[int] = -1) -> bytes:
         return self._f.readline(limit)
 
-    def seek(self, offset, whence=os.SEEK_SET):
+    def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
         if whence not in (os.SEEK_CUR, os.SEEK_END, os.SEEK_SET):
             raise ValueError("invalid value for 'whence'")
         self._f.seek(offset, whence)
         return self._f.tell()
 
-    def seekable(self):
+    def seekable(self) -> bool:
         return True
 
-    def tell(self):
+    def tell(self) -> int:
         return self._f.tell()
 
-    def writable(self):
+    def writable(self) -> bool:
         return self.mode.writing
 
-    def writelines(self, lines):
+    def writelines(self, lines) -> None:
         return self._f.writelines(lines)
 
-    def read(self, n=-1):
+    def read(self, n: int = -1) -> bytes:
         if not self.mode.reading:
             raise OSError("not open for reading")
         return self._f.read(n)
 
-    def readall(self):
+    def readall(self) -> bytes:
         return self._f.read()
 
-    def readinto(self, b):
+    def readinto(self, b) -> int:
         return self._f.readinto(b)
 
-    def write(self, b):
+    def write(self, b) -> int:
         if not self.mode.writing:
             raise OSError("not open for writing")
         self._f.write(b)
         return len(b)
 
-    def truncate(self, size=None):
+    def truncate(self, size: Optional[int] = None) -> int:
         if size is None:
             size = self._f.tell()
         self._f.truncate(size)
         return size
 
-    def __next__(self):
+    def __next__(self) -> bytes:
         line = self._f.readline()
         if not line:
             raise StopIteration

--- a/fs/azblob/blob_file.py
+++ b/fs/azblob/blob_file.py
@@ -7,7 +7,9 @@ from fs.mode import Mode
 
 
 class BlobFile(io.IOBase):
-    """Proxy for a blob file."""
+    """Proxy for a blob file. Implements the standard file api.
+    See https://docs.python.org/3/library/io.html#io.IOBase
+    """
 
     @classmethod
     def factory(cls, blob, mode):

--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -124,6 +124,7 @@ class BlobFS(FS):
 
     def _check_mode(self, path, mode):
         mode.validate_bin()
+        # mode = mode.to_platform_bin()
         try:
             info = self.getinfo(path)
             if mode.exclusive:
@@ -139,9 +140,17 @@ class BlobFS(FS):
             path = ""
         return path.strip("/")
 
+    def _check_makedir(self, path, recreate):
+        if not self.isdir(dirname(path)):
+            raise errors.ResourceNotFound(path)
+        if not recreate:
+            if path == "" or self.exists(path):
+                raise errors.DirectoryExists(path)
+
     def makedir(self, path: str, permissions=None, recreate: bool = False) -> SubFS:  # type: ignore
         self.check()
         path = self.validatepath(path)
+        self._check_makedir(path, recreate)
         self.touch(path + "/" + DIR_ENTRY)
         return SubFS(self, path)
 

--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -50,6 +50,7 @@ class BlobFS(FS):
         )
 
     def getinfo(self, path: str, namespaces=None) -> Info:
+        self.check()
         namespaces = namespaces or ()
         path = self.validatepath(path)
         if path == "":
@@ -80,6 +81,7 @@ class BlobFS(FS):
         return Info(info)
 
     def listdir(self, path: str) -> list:
+        self.check()
         path = self.validatepath(path)
         parts = path.split("/")
         num_parts = 0 if path == "" else len(parts)
@@ -91,6 +93,7 @@ class BlobFS(FS):
     def openbin(
         self, path: str, mode: str = "r", buffering: int = -1, **options: Any
     ) -> BinaryIO:
+        self.check()
         path = self.validatepath(path)
         _mode = Mode(mode)
         return BlobFile(self.client.get_blob_client(path), _mode)  # type: ignore
@@ -105,15 +108,18 @@ class BlobFS(FS):
         return path
 
     def makedir(self, path: str, permissions=None, recreate: bool = False) -> SubFS:  # type: ignore
+        self.check()
         path = self.validatepath(path)
         return SubFS(self, path)
 
     def remove(self, path: str) -> None:
+        self.check()
         path = self.validatepath(path)
         with blobfs_errors(path):
             self.client.delete_blob(path)
 
     def removedir(self, path: str) -> None:
+        self.check()
         logger.warning("Directories not supported for azblob filesystem")
 
     def setinfo(self, path: str, info) -> None:

--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -7,7 +7,7 @@ from fs.base import FS
 from fs.enums import ResourceType
 from fs.info import Info
 from fs.mode import Mode
-from fs.path import basename, dirname
+from fs.path import abspath, basename, dirname, normpath
 from fs.subfs import SubFS
 from fs.time import datetime_to_epoch
 
@@ -138,8 +138,7 @@ class BlobFS(FS):
                 raise errors.ResourceNotFound(path)
 
     def validatepath(self, path: str) -> str:
-        if path == ".":
-            path = ""
+        path = abspath(normpath(path))
         return path.strip("/")
 
     def _check_makedir(self, path, recreate):

--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -45,7 +45,7 @@ def _basic_info(name: str, is_dir: bool) -> dict:
     return {BASIC: {NAME: name, IS_DIR: is_dir}}
 
 
-def _info_from_dict(info, namespaces):
+def _info_from_dict(info: dict, namespaces) -> Info:
     if DETAILS in namespaces:
         if DETAILS not in info:
             info[DETAILS] = {}
@@ -95,12 +95,13 @@ class BlobFS(FS):
         info = _basic_info(name=base_name, is_dir=False)
         if DETAILS in namespaces:
             props = blob.get_blob_properties()
-            details = {}
-            details[ACCESSED] = props[LAST_ACCESSED_ON]
-            details[CREATED] = props[CREATION_TIME]
-            details[METADATA_CHANGED] = None
-            details[MODIFIED] = props[LAST_MODIFIED]
-            details[SIZE] = props[SIZE]
+            details = {
+                ACCESSED: props[LAST_ACCESSED_ON],
+                CREATED: props[CREATION_TIME],
+                METADATA_CHANGED: None,
+                MODIFIED: props[LAST_MODIFIED],
+                SIZE: props[SIZE],
+            }
             _convert_to_epoch(details)
             info[DETAILS] = details
 
@@ -143,7 +144,7 @@ class BlobFS(FS):
 
         return blob_file  # type: ignore
 
-    def _check_dir_path(self, path):
+    def _check_dir_path(self, path: str) -> None:
         try:
             dir_path = dirname(path)
             self.getinfo(dir_path)
@@ -151,7 +152,7 @@ class BlobFS(FS):
             if DIR_ENTRY != basename(path):
                 raise errors.ResourceNotFound(path)
 
-    def _check_mode(self, path, mode):
+    def _check_mode(self, path: str, mode: Mode) -> None:
         mode.validate_bin()
         try:
             info = self.getinfo(path)
@@ -168,10 +169,9 @@ class BlobFS(FS):
         if _path.endswith("."):
             raise errors.InvalidPath(path)
 
-        # return quote(_path).strip("/")
         return _path.strip("/")
 
-    def _check_makedir(self, path, recreate):
+    def _check_makedir(self, path: str, recreate: bool) -> None:
         if not self.isdir(dirname(path)):
             raise errors.ResourceNotFound(path)
         if not recreate:

--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -141,7 +141,14 @@ class BlobFS(FS):
 
     def removedir(self, path: str) -> None:
         self.check()
-        logger.warning("Directories not supported for azblob filesystem")
+        _path = self.validatepath(path)
+        if _path == "":
+            raise errors.RemoveRootError()
+        info = self.getinfo(_path)
+        if not info.is_dir:
+            raise errors.DirectoryExpected(path)
+        if not self.isempty(path):
+            raise errors.DirectoryNotEmpty(path)
 
     def setinfo(self, path: str, info) -> None:
         self.check()

--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -169,6 +169,8 @@ class BlobFS(FS):
     def remove(self, path: str) -> None:
         self.check()
         path = self.validatepath(path)
+        if self.getinfo(path).is_dir:
+            raise errors.FileExpected(path)
         with blobfs_errors(path):
             self.client.delete_blob(path)
 

--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-import os
 from typing import Any, BinaryIO
 
 from azure.storage.blob import ContainerClient
@@ -121,10 +120,12 @@ class BlobFS(FS):
             stream = blob.download_blob()
             stream.readinto(blob_file.raw)
 
-        if _mode.appending:
-            blob_file.seek(0, os.SEEK_END)
-        else:
+        if _mode.truncate:
             blob_file.seek(0)
+            blob_file.truncate()
+        elif not _mode.appending:
+            blob_file.seek(0)
+
         return blob_file  # type: ignore
 
     def _check_dir_path(self, path):

--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -96,6 +96,8 @@ class BlobFS(FS):
     def listdir(self, path: str) -> list:
         self.check()
         path = self.validatepath(path)
+        if not self.getinfo(path).is_dir:
+            raise errors.DirectoryExpected(path)
         parts = path.split("/")
         num_parts = 0 if path == "" else len(parts)
         suffix = parts[-1]

--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -89,9 +89,9 @@ class BlobFS(FS):
         num_parts = 0 if path == "" else len(parts)
         suffix = parts[-1]
         with blobfs_errors(path):
-            _all = (b.name.split("/") for b in self.client.list_blobs(path))
-            _all = (p[num_parts] for p in _all if suffix in p or suffix == "")
-            return [a for a in _all if a != DIR_ENTRY]
+            _all = [b.name.split("/") for b in self.client.list_blobs(path)]
+            _all = [p[num_parts] for p in _all if suffix in p or suffix == ""]
+            return list({a for a in _all if a != DIR_ENTRY})
 
     def openbin(
         self, path: str, mode: str = "r", buffering: int = -1, **options: Any

--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -115,9 +115,9 @@ class BlobFS(FS):
         _mode = Mode(mode)
 
         self._check_mode(path, _mode)
-        # self._check_dir_path(path)
+        self._check_dir_path(path)
         blob = self.client.get_blob_client(path)
-        blob_file = BlobFile.factory(blob, _mode)
+        blob_file = BlobFile.factory(blob, _mode.to_platform_bin())
 
         if self.exists(path):
             stream = blob.download_blob()
@@ -134,11 +134,11 @@ class BlobFS(FS):
             dir_path = dirname(path)
             self.getinfo(dir_path)
         except errors.ResourceNotFound:
-            raise errors.ResourceNotFound(path)
+            if DIR_ENTRY != basename(path):
+                raise errors.ResourceNotFound(path)
 
     def _check_mode(self, path, mode):
         mode.validate_bin()
-        # mode = mode.to_platform_bin()
         try:
             info = self.getinfo(path)
             if mode.exclusive:

--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -70,14 +70,12 @@ class BlobFS(FS):
 
     def _check_container_client(self):
         try:
-            if self.client.exists():
-                return
+            if not self.client.exists():
+                raise errors.CreateFailed("Container does not exist")
         except:  # noqa
-            # if no credentials are provided, the check raises an auth error
-            pass
-        raise errors.FSError(
-            "Invalid parameters. Either incorrect account details, or container does not exist"
-        )
+            raise errors.CreateFailed(
+                "Invalid parameters. Either incorrect account details, or container does not exist"
+            )
 
     def getinfo(self, path: str, namespaces=None) -> Info:
         self.check()

--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -118,10 +118,8 @@ class BlobFS(FS):
         # self._check_dir_path(path)
         blob = self.client.get_blob_client(path)
         blob_file = BlobFile.factory(blob, _mode)
-        if _mode.create:
-            return blob_file
 
-        with blobfs_errors(path):
+        if self.exists(path):
             stream = blob.download_blob()
             stream.readinto(blob_file.raw)
 

--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -125,12 +125,14 @@ class BlobFS(FS):
     def setinfo(self, path: str, info) -> None:
         self.check()
         path = self.validatepath(path)
-        with blobfs_errors(path):
-            blob = self.client.get_blob_client(path)
-            if "details" in info:
-                details = info["details"]
-                meta = {
-                    "last_accessed_on": str(details["accessed"]),
-                    "last_modified": str(details["modified"]),
-                }
+        if not self.exists(path):
+            raise ResourceNotFound(path)
+        if "details" in info:
+            details = info["details"]
+            meta = {
+                "last_accessed_on": str(details["accessed"]),
+                "last_modified": str(details["modified"]),
+            }
+            with blobfs_errors(path):
+                blob = self.client.get_blob_client(path)
                 blob.set_blob_metadata(meta)

--- a/fs/azblob/const.py
+++ b/fs/azblob/const.py
@@ -1,0 +1,30 @@
+# Placeholder for a directory. An empty blob with this name is created/removed when a
+# directory is created/removed. It is excluded from list operations.
+DIR_ENTRY = ".fs_azblob"
+
+# getinfo keys
+BASIC = "basic"
+DETAILS = "details"
+TYPE = "type"
+IS_DIR = "is_dir"
+NAME = "name"
+ACCESSED = "accessed"
+MODIFIED = "modified"
+CREATED = "created"
+METADATA_CHANGED = "metadata_changed"
+SIZE = "size"
+
+# property names from azure sdk
+LAST_ACCESSED_ON = "last_accessed_on"
+CREATION_TIME = "creation_time"
+LAST_MODIFIED = "last_modified"
+
+
+def _build_invalid_chars():
+    ctrl_chars = "".join([chr(i) for i in range(32)])
+    backslash = "\\"
+    delete = chr(127)  # \x7F
+    return ctrl_chars + backslash + delete
+
+
+INVALID_CHARS = _build_invalid_chars()

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,5 @@
+import os
+
 import nox
 
 nox.options.sessions = ["lint", "test", "mypy", "pytype"]
@@ -8,7 +10,11 @@ locations = ["fs", "tests", "noxfile.py"]
 def test(session):
     session.install("pytest")
     session.install(".")
-    session.run("pytest", "-m", "not creds")
+    key = os.getenv("BLOB_ACCOUNT_KEY")
+    if key is None:
+        session.run("pytest", "-m", "not creds")
+    else:
+        session.run("pytest")
 
 
 @nox.session

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,6 @@ ignore_missing_imports = false
 disable = import-error
 
 [tool:pytest]
-addopts = -s
+# addopts = -s
 markers =
     creds: marks tests which require credentials (deselect with '-m "not creds"')

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,14 +7,12 @@ from fs.test import FSTestCases
 from fs.azblob import BlobFS
 
 
-@pytest.mark.skip
+@pytest.mark.creds
 class TestBlobFS(FSTestCases, unittest.TestCase):
-    def destroy_fs(self, fs):
-        while any(fs.listdir("/")):
-            fs.removetree("/")
-
     def make_fs(self):
         account_name = "besciences"
         container = "test3"
         key = os.getenv("BLOB_ACCOUNT_KEY")
-        return BlobFS(account_name, container, key)
+        bfs = BlobFS(account_name, container, key)
+        bfs.removetree("/")
+        return bfs

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,20 @@
+import os
+import unittest
+
+import pytest
+from fs.test import FSTestCases
+
+from fs.azblob import BlobFS
+
+
+@pytest.mark.skip
+class TestBlobFS(FSTestCases, unittest.TestCase):
+    def destroy_fs(self, fs):
+        while any(fs.listdir("/")):
+            fs.removetree("/")
+
+    def make_fs(self):
+        account_name = "besciences"
+        container = "test3"
+        key = os.getenv("BLOB_ACCOUNT_KEY")
+        return BlobFS(account_name, container, key)

--- a/tests/test_blob_fs.py
+++ b/tests/test_blob_fs.py
@@ -50,7 +50,7 @@ def new_file(bfs_rw, content):
 
 
 def test_listdir(bfs):
-    for path in ("", ".", "/", "raw", "raw/test_usa_tamu", "raw/test"):
+    for path in ("", ".", "/", "raw", "raw/test_usa_tamu"):
         print(f"{path=}")
         print(bfs.listdir(path))
 

--- a/tests/test_blob_fs.py
+++ b/tests/test_blob_fs.py
@@ -110,11 +110,12 @@ def test_makedirs(bfs_rw):
 def test_copy_fs(account_key):
     src = BlobFS(account_name, "test", account_key=account_key)
     dest = BlobFS(account_name, "test2", account_key=account_key)
-    paths = ("foo/bar", "foo")
-    for path in paths:
-        fs.copy.copy_dir(src, path, dest, path)
-        dest.removetree(path)
-        assert len(dest.listdir(".")) == 0
+    path = "foo/bar"
+    fs.copy.copy_dir(src, path, dest, path)
+    assert "foo" in dest.listdir(".")
+    assert "bar" in dest.listdir("foo")
+    dest.removetree(".")
+    assert len(dest.listdir(".")) == 0
 
 
 class TestBlobFile:

--- a/tests/test_blob_fs.py
+++ b/tests/test_blob_fs.py
@@ -150,12 +150,12 @@ class TestOpener:
 
     def test_opener_error_wrong_container(self):
         url = f"azblob://{account_name}@{str(uuid4())}"
-        with pytest.raises(errors.FSError):
+        with pytest.raises(errors.CreateFailed):
             open_fs(url)
 
     def test_opener_error_wrong_key(self):
         url = f"azblob://{account_name}:asdf@{container}"
-        with pytest.raises(errors.FSError):
+        with pytest.raises(errors.CreateFailed):
             open_fs(url)
 
 

--- a/tests/test_blob_fs.py
+++ b/tests/test_blob_fs.py
@@ -103,6 +103,7 @@ def test_makedirs(bfs_rw):
         list1 = sub_fs.listdir(".")
         list2 = bfs_rw.listdir(path)
         assert list1 == list2 == [fname]
+    bfs_rw.removetree(path)
 
 
 @pytest.mark.creds
@@ -206,7 +207,7 @@ class TestUpload:
         fname = "duplicate.txt"
         bfs_rw.upload(fname, io.BytesIO(b"foo"))
         bfs_rw.upload(fname, io.BytesIO(b"bar"))
-        assert b"bar" == bfs_rw.getbytes(fname)
+        assert b"bar" == bfs_rw.readbytes(fname)
         bfs_rw.remove(fname)
 
     @pytest.mark.skip

--- a/tests/test_blob_fs.py
+++ b/tests/test_blob_fs.py
@@ -147,16 +147,6 @@ class TestBlobFile:
             assert not bfile.closed
         assert bfile.closed
 
-    def test_validate_mode(self):
-        bc = BlobClient(url, container, "some_file")
-        with BlobFile(bc, Mode("r")) as bfile:
-            with pytest.raises(ValueError):
-                _ = bfile.writer
-
-        # with BlobFile(bc, Mode("w")) as bfile:
-        #     with pytest.raises(ValueError):
-        #         _ = bfile.reader
-
     @pytest.mark.creds
     def test_iterate_lines(self, bfs_rw):
         with new_file(bfs_rw, b"line1\nline2\n\n") as fname:


### PR DESCRIPTION
### Purpose
Pyfilesystem provides a test suite ([docs](https://docs.pyfilesystem.org/en/latest/implementers.html#testing-filesystems) and [source](https://docs.pyfilesystem.org/en/latest/_modules/fs/test.html#FSTestCases), currently 77 tests) which essentially defines the spec that any filesystem must conform to. This PR makes it so the blob fs passes all of the tests. They are not run by github, but can be run using `pytest tests/test.py`, provided the account key is set as an environment variable. 

### What the code is doing
* Reimplement `BlobFile` class to use an underlying tempfile, which gives us the file api "for free"
* Add a bunch of error handling, for consistency with other filesystems
* Implement directories by adding a `.fs_azblob` file which acts as a placeholder (and is cleaned up when a directory is deleted)
* Add release.yml workflow, which will run when we eventually create a tagged release

### Testing
Ran `test.py`, as described above. Everything else is run by CI.


### Usage Example/Visuals
It is used the same as before, but works better.

### Time estimate
30 mins (depends on how deep you want to go)
