### PR TITLE
Add support for hierarchical namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,28 @@ Either approach will also install the core `fs` package if it's not already inst
 
 ## Usage
 
+This library implements the pyfilesystem API for blob storage containers in a general
+purpose storage account. There are implementations for the original blob storage, which
+uses a flat namespace with virtual directories, and accounts with hierarchical namespace
+enabled, which adds native directory support as well as other features. The type of
+account must be specified when a filesystem is instantiated: use the `azblob` protocol,
+or `BlobFS` class for accounts with a flat namespace, or the `azblobv2` protocol or the
+`BlobFSV2` class for accounts with a hierarchical namespace. 
+
 ### Opener
 
 Use `fs.open_fs` to open a filesystem with an azure blob
-[FS URL](https://docs.pyfilesystem.org/en/latest/openers.html):
+[FS URL](https://docs.pyfilesystem.org/en/latest/openers.html), where `protocol` is
+either `azblob` or `azblobv2`:
 
 ```python
 import fs
-my_fs = fs.open_fs("azblob://[account_name]:[account_key]@[container]")
+my_fs = fs.open_fs("[protocol]://[account_name]:[account_key]@[container]")
 ```
 
 ### Constructor
 
-The `BlobFS` class can also be instantiated directly
+The `BlobFS` (or `BlobFSV2`) class can also be instantiated directly
 
 ```python
 from fs.azblob import BlobFS
@@ -54,6 +63,8 @@ using the following arguments:
 - `account_key`: optional, but required for write operations or depending on the storage account access policies
 
 ## Note
+The following can be ignored if using an account with hierarchical namespace.
+
 Since blob storage uses a flat namespace (directories don't really exist), we create a
 placeholder file to represent them, always named `.fs_azblob`. This is an empty blob
 which is created for new directories, removed when a directory is removed, and omitted

--- a/fs/azblob/__init__.py
+++ b/fs/azblob/__init__.py
@@ -1,1 +1,3 @@
-from .blob_fs import BlobFile, BlobFS  # noqa: F401
+from .blob_file import BlobFile  # noqa: F401
+from .blob_fs import BlobFS  # noqa: F401
+from .blob_fs_v2 import BlobFSV2  # noqa: F401

--- a/fs/azblob/blob_file.py
+++ b/fs/azblob/blob_file.py
@@ -19,7 +19,7 @@ class BlobFile(io.IOBase):
         return proxy
 
     def __repr__(self):
-        return f"BlobFile({self._name}, {self.mode})"
+        return f"BlobFile({self._name()}, {self.mode})"
 
     def __init__(self, f, blob, mode, version):
         self._f = f
@@ -34,10 +34,13 @@ class BlobFile(io.IOBase):
             return self._blob.path_name
 
     def _upload(self):
-        if self.version == 1:
+        version = self.version
+        if version == 1:
             self._blob.upload_blob(self.raw, overwrite=True)
-        if self.version == 2:
+        elif version == 2:
             self._blob.upload_data(self.raw, overwrite=True)
+        else:
+            raise ValueError(f"Unknown sdk {version=}")
 
     def __enter__(self):
         return self

--- a/fs/azblob/blob_file.py
+++ b/fs/azblob/blob_file.py
@@ -19,19 +19,26 @@ class BlobFile(io.IOBase):
         return proxy
 
     def __repr__(self):
-        return f"BlobFile({self._name()}, {self.mode})"
+        return f"BlobFile({self._name}, {self.mode})"
 
     def __init__(self, f, blob, mode, version):
         self._f = f
         self._blob = blob
         self.mode = Mode(mode)
+        self._set_version(version)
+        self._set_name()
+
+    def _set_version(self, version):
+        if version not in (1, 2):
+            raise ValueError(f"Unknown sdk {version=}")
         self.version = version
 
-    def _name(self):
+    def _set_name(self):
+        blob = self._blob
         if self.version == 1:
-            return self._blob.blob_name
+            self._name = blob.blob_name
         if self.version == 2:
-            return self._blob.path_name
+            self._name = blob.path_name
 
     def _upload(self):
         version = self.version
@@ -39,8 +46,6 @@ class BlobFile(io.IOBase):
             self._blob.upload_blob(self.raw, overwrite=True)
         elif version == 2:
             self._blob.upload_data(self.raw, overwrite=True)
-        else:
-            raise ValueError(f"Unknown sdk {version=}")
 
     def __enter__(self):
         return self

--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -120,7 +120,7 @@ class BlobFS(FS):
         self._check_mode(path, _mode)
         self._check_dir_path(path)
         blob = self.client.get_blob_client(path)
-        blob_file = BlobFile.factory(blob, _mode.to_platform_bin())
+        blob_file = BlobFile.factory(blob, _mode.to_platform_bin(), version=1)
 
         if self.exists(path):
             stream = blob.download_blob()

--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -1,14 +1,11 @@
-import datetime
 from typing import Any, BinaryIO
 
 from azure.storage.blob import ContainerClient
 from fs.base import FS
-from fs.enums import ResourceType
 from fs.info import Info
 from fs.mode import Mode
 from fs.path import basename, dirname, join
 from fs.subfs import SubFS
-from fs.time import datetime_to_epoch
 
 from fs import errors
 from fs.azblob.blob_file import BlobFile
@@ -27,30 +24,13 @@ from fs.azblob.const import (
     MODIFIED,
     NAME,
     SIZE,
-    TYPE,
 )
 from fs.azblob.error_tools import blobfs_errors
-
-
-def _convert_to_epoch(props: dict) -> None:
-    for k, v in props.items():
-        if isinstance(v, datetime.datetime):
-            props[k] = datetime_to_epoch(v)
+from fs.azblob.helpers import _convert_to_epoch, _info_from_dict
 
 
 def _basic_info(name: str, is_dir: bool) -> dict:
     return {BASIC: {NAME: name, IS_DIR: is_dir}}
-
-
-def _info_from_dict(info: dict, namespaces) -> Info:
-    if DETAILS in namespaces:
-        if DETAILS not in info:
-            info[DETAILS] = {}
-        if info[BASIC][IS_DIR]:
-            info[DETAILS][TYPE] = ResourceType.directory
-        else:
-            info[DETAILS][TYPE] = ResourceType.file
-    return Info(info)
 
 
 class BlobFS(FS):

--- a/fs/azblob/blob_fs_v2.py
+++ b/fs/azblob/blob_fs_v2.py
@@ -105,11 +105,11 @@ class BlobFSV2(FS):
 
         self._check_mode(path, _mode)
         self._check_dir_path(path)
-        blob = self.client.get_blob_client(path)
-        blob_file = BlobFile.factory(blob, _mode.to_platform_bin())
+        blob = self.client.get_file_client(path)
+        blob_file = BlobFile.factory(blob, _mode.to_platform_bin(), version=2)
 
         if self.exists(path):
-            stream = blob.download_blob()
+            stream = blob.download_file()
             stream.readinto(blob_file.raw)
 
         if _mode.truncate:
@@ -194,5 +194,5 @@ class BlobFSV2(FS):
                 LAST_MODIFIED: str(details[MODIFIED]),
             }
             with blobfs_errors(path):
-                blob = self.client.get_blob_client(path)
-                blob.set_blob_metadata(meta)
+                blob = self.client.get_file_client(path)
+                blob.set_metadata(meta)

--- a/fs/azblob/blob_fs_v2.py
+++ b/fs/azblob/blob_fs_v2.py
@@ -1,14 +1,11 @@
-import datetime
 from typing import Any, BinaryIO
 
 from azure.storage.filedatalake import DataLakeServiceClient
 from fs.base import FS
-from fs.enums import ResourceType
 from fs.info import Info
 from fs.mode import Mode
 from fs.path import dirname
 from fs.subfs import SubFS
-from fs.time import datetime_to_epoch
 
 from fs import errors
 from fs.azblob.blob_file import BlobFile
@@ -26,15 +23,9 @@ from fs.azblob.const import (
     MODIFIED,
     NAME,
     SIZE,
-    TYPE,
 )
 from fs.azblob.error_tools import blobfs_errors
-
-
-def _convert_to_epoch(props: dict) -> None:
-    for k, v in props.items():
-        if isinstance(v, datetime.datetime):
-            props[k] = datetime_to_epoch(v)
+from fs.azblob.helpers import _convert_to_epoch, _info_from_dict
 
 
 def _is_dir(blob):
@@ -48,17 +39,6 @@ def _is_dir(blob):
 
 def _basic_info(props) -> dict:
     return {BASIC: {NAME: props[NAME], IS_DIR: _is_dir(props)}}
-
-
-def _info_from_dict(info: dict, namespaces) -> Info:
-    if DETAILS in namespaces:
-        if DETAILS not in info:
-            info[DETAILS] = {}
-        if info[BASIC][IS_DIR]:
-            info[DETAILS][TYPE] = ResourceType.directory
-        else:
-            info[DETAILS][TYPE] = ResourceType.file
-    return Info(info)
 
 
 class BlobFSV2(FS):

--- a/fs/azblob/blob_fs_v2.py
+++ b/fs/azblob/blob_fs_v2.py
@@ -142,11 +142,7 @@ class BlobFSV2(FS):
                 raise errors.ResourceNotFound(path)
 
     def _validatepath(self, path: str) -> str:
-        _path = super().validatepath(path)
-        if _path.endswith("."):
-            raise errors.InvalidPath(path)
-
-        return _path.strip("/")
+        return super().validatepath(path)
 
     def _check_makedir(self, path: str, recreate: bool) -> None:
         if not self.isdir(dirname(path)):

--- a/fs/azblob/blob_fs_v2.py
+++ b/fs/azblob/blob_fs_v2.py
@@ -1,0 +1,209 @@
+import datetime
+from typing import Any, BinaryIO
+
+from azure.storage.filedatalake import DataLakeServiceClient
+from fs.base import FS
+from fs.enums import ResourceType
+from fs.info import Info
+from fs.mode import Mode
+from fs.path import dirname
+from fs.subfs import SubFS
+from fs.time import datetime_to_epoch
+
+from fs import errors
+from fs.azblob.blob_file import BlobFile
+from fs.azblob.const import (
+    ACCESSED,
+    BASIC,
+    CREATED,
+    CREATION_TIME,
+    DETAILS,
+    INVALID_CHARS,
+    IS_DIR,
+    LAST_ACCESSED_ON,
+    LAST_MODIFIED,
+    METADATA_CHANGED,
+    MODIFIED,
+    NAME,
+    SIZE,
+    TYPE,
+)
+from fs.azblob.error_tools import blobfs_errors
+
+
+def _convert_to_epoch(props: dict) -> None:
+    for k, v in props.items():
+        if isinstance(v, datetime.datetime):
+            props[k] = datetime_to_epoch(v)
+
+
+def _is_dir(blob):
+    metadata = blob["metadata"]
+    if metadata is not None:
+        if "hdi_isfolder" in metadata:
+            if metadata["hdi_isfolder"] == "true":
+                return True
+    return False
+
+
+def _info_from_dict(props: dict, namespaces) -> Info:
+    info = {BASIC: {NAME: props[NAME], IS_DIR: _is_dir(props)}}
+    if DETAILS in namespaces:
+        details = {
+            ACCESSED: props[LAST_ACCESSED_ON],
+            CREATED: props[CREATION_TIME],
+            METADATA_CHANGED: None,
+            MODIFIED: props[LAST_MODIFIED],
+            SIZE: props[SIZE],
+        }
+        if info[BASIC][IS_DIR]:
+            info[DETAILS][TYPE] = ResourceType.directory
+        else:
+            info[DETAILS][TYPE] = ResourceType.file
+
+        _convert_to_epoch(details)
+        info[DETAILS] = details
+    return Info(info)
+
+
+class BlobFSV2(FS):
+    _meta = {"invalid_path_chars": INVALID_CHARS}
+
+    def __init__(self, account_name: str, container: str, account_key=None):
+        super().__init__()
+        self._svc = DataLakeServiceClient(
+            account_url=f"https://{account_name}.dfs.core.windows.net",
+            credential=account_key,
+        )
+        self.client = self._svc.get_file_system_client(container)
+        self._check_container_client()
+
+    def _check_container_client(self):
+        try:
+            if not self.client.exists():
+                raise errors.CreateFailed("Container does not exist")
+        except:  # noqa
+            raise errors.CreateFailed(
+                "Invalid parameters. Either incorrect account details, or container does not exist"
+            )
+
+    def getinfo(self, path: str, namespaces=None) -> Info:
+        self.check()
+        namespaces = namespaces or ()
+        path = self._validatepath(path)
+
+        blob = self.client.get_file_client(path)
+        if not blob.exists():
+            raise errors.ResourceNotFound(path)
+
+        props = dict(blob.get_file_properties())
+        return _info_from_dict(props, namespaces)
+
+    def listdir(self, path: str) -> list:
+        self.check()
+        path = self._validatepath(path)
+        if not self.getinfo(path).is_dir:
+            raise errors.DirectoryExpected(path)
+        paths = self.client.get_paths(path, recursive=False)
+        return [p["name"].split("/")[-1] for p in paths]
+
+    def openbin(
+        self, path: str, mode: str = "r", buffering: int = -1, **options: Any
+    ) -> BinaryIO:
+        self.check()
+        path = self._validatepath(path)
+        _mode = Mode(mode)
+
+        self._check_mode(path, _mode)
+        self._check_dir_path(path)
+        blob = self.client.get_blob_client(path)
+        blob_file = BlobFile.factory(blob, _mode.to_platform_bin())
+
+        if self.exists(path):
+            stream = blob.download_blob()
+            stream.readinto(blob_file.raw)
+
+        if _mode.truncate:
+            blob_file.seek(0)
+            blob_file.truncate()
+        elif not _mode.appending:
+            blob_file.seek(0)
+
+        return blob_file  # type: ignore
+
+    def _check_dir_path(self, path: str) -> None:
+        """Ensure the parent directory of path exists"""
+        try:
+            dir_path = dirname(path)
+            self.getinfo(dir_path)
+        except errors.ResourceNotFound:
+            raise errors.ResourceNotFound(path)
+
+    def _check_mode(self, path: str, mode: Mode) -> None:
+        """Ensure path can be opened using the given mode"""
+        mode.validate_bin()
+        try:
+            info = self.getinfo(path)
+            if mode.exclusive:
+                raise errors.FileExists(path)
+            if info.is_dir:
+                raise errors.FileExpected(path)
+        except errors.ResourceNotFound:
+            if not mode.create:
+                raise errors.ResourceNotFound(path)
+
+    def _validatepath(self, path: str) -> str:
+        _path = super().validatepath(path)
+        if _path.endswith("."):
+            raise errors.InvalidPath(path)
+
+        return _path.strip("/")
+
+    def _check_makedir(self, path: str, recreate: bool) -> None:
+        if not self.isdir(dirname(path)):
+            raise errors.ResourceNotFound(path)
+        if not recreate:
+            if path == "" or self.exists(path):
+                raise errors.DirectoryExists(path)
+
+    def makedir(self, path: str, permissions=None, recreate: bool = False) -> SubFS:  # type: ignore
+        self.check()
+        path = self._validatepath(path)
+        self._check_makedir(path, recreate)
+        self.client.create_directory(path)
+        return SubFS(self, path)
+
+    def remove(self, path: str) -> None:
+        self.check()
+        path = self._validatepath(path)
+        if self.getinfo(path).is_dir:
+            raise errors.FileExpected(path)
+        with blobfs_errors(path):
+            self.client.delete_file(path)
+
+    def removedir(self, path: str) -> None:
+        self.check()
+        _path = self._validatepath(path)
+        if _path == "":
+            raise errors.RemoveRootError()
+        info = self.getinfo(_path)
+        if not info.is_dir:
+            raise errors.DirectoryExpected(path)
+        if not self.isempty(path):
+            raise errors.DirectoryNotEmpty(path)
+        self.client.delete_directory(path)
+
+    def setinfo(self, path: str, info) -> None:
+        self.check()
+        path = self._validatepath(path)
+        if not self.exists(path):
+            raise errors.ResourceNotFound(path)
+        if DETAILS in info:
+            details = info[DETAILS]
+            meta = {
+                LAST_ACCESSED_ON: str(details[ACCESSED]),
+                LAST_MODIFIED: str(details[MODIFIED]),
+            }
+            with blobfs_errors(path):
+                blob = self.client.get_blob_client(path)
+                blob.set_blob_metadata(meta)

--- a/fs/azblob/blob_fs_v2.py
+++ b/fs/azblob/blob_fs_v2.py
@@ -17,7 +17,6 @@ from fs.azblob.const import (
     DETAILS,
     INVALID_CHARS,
     IS_DIR,
-    LAST_ACCESSED_ON,
     LAST_MODIFIED,
     METADATA_CHANGED,
     MODIFIED,
@@ -79,7 +78,7 @@ class BlobFSV2(FS):
 
         if DETAILS in namespaces:
             details = {
-                ACCESSED: props[LAST_ACCESSED_ON],
+                ACCESSED: None,
                 CREATED: props[CREATION_TIME],
                 METADATA_CHANGED: None,
                 MODIFIED: props[LAST_MODIFIED],
@@ -158,7 +157,9 @@ class BlobFSV2(FS):
         self.check()
         path = self._validatepath(path)
         self._check_makedir(path, recreate)
-        self.client.create_directory(path)
+        dir_client = self.client.get_directory_client(path)
+        if not dir_client.exists():
+            dir_client.create_directory()
         return SubFS(self, path)
 
     def remove(self, path: str) -> None:
@@ -189,7 +190,7 @@ class BlobFSV2(FS):
         if DETAILS in info:
             details = info[DETAILS]
             meta = {
-                LAST_ACCESSED_ON: str(details[ACCESSED]),
+                # TODO: custom metadata?
                 LAST_MODIFIED: str(details[MODIFIED]),
             }
             with blobfs_errors(path):

--- a/fs/azblob/blob_fs_v2.py
+++ b/fs/azblob/blob_fs_v2.py
@@ -64,7 +64,7 @@ class BlobFSV2(FS):
     def getinfo(self, path: str, namespaces=None) -> Info:
         self.check()
         namespaces = namespaces or ()
-        _path = self._validatepath(path)
+        _path = self.validatepath(path)
 
         blob = self.client.get_file_client(_path)
         if not blob.exists():
@@ -90,7 +90,7 @@ class BlobFSV2(FS):
 
     def listdir(self, path: str) -> list:
         self.check()
-        path = self._validatepath(path)
+        path = self.validatepath(path)
         if not self.getinfo(path).is_dir:
             raise errors.DirectoryExpected(path)
         paths = self.client.get_paths(path, recursive=False)
@@ -100,7 +100,7 @@ class BlobFSV2(FS):
         self, path: str, mode: str = "r", buffering: int = -1, **options: Any
     ) -> BinaryIO:
         self.check()
-        path = self._validatepath(path)
+        path = self.validatepath(path)
         _mode = Mode(mode)
 
         self._check_mode(path, _mode)
@@ -143,9 +143,6 @@ class BlobFSV2(FS):
             if not mode.create:
                 raise errors.ResourceNotFound(path)
 
-    def _validatepath(self, path: str) -> str:
-        return super().validatepath(path)
-
     def _check_makedir(self, path: str, recreate: bool) -> None:
         if not self.isdir(dirname(path)):
             raise errors.ResourceNotFound(path)
@@ -155,7 +152,7 @@ class BlobFSV2(FS):
 
     def makedir(self, path: str, permissions=None, recreate: bool = False) -> SubFS:  # type: ignore
         self.check()
-        path = self._validatepath(path)
+        path = self.validatepath(path)
         self._check_makedir(path, recreate)
         dir_client = self.client.get_directory_client(path)
         if not dir_client.exists():
@@ -164,7 +161,7 @@ class BlobFSV2(FS):
 
     def remove(self, path: str) -> None:
         self.check()
-        _path = self._validatepath(path)
+        _path = self.validatepath(path)
         if self.getinfo(path).is_dir:
             raise errors.FileExpected(path)
         with blobfs_errors(path):
@@ -172,8 +169,8 @@ class BlobFSV2(FS):
 
     def removedir(self, path: str) -> None:
         self.check()
-        path = self._validatepath(path)
-        if path == "":
+        path = self.validatepath(path)
+        if path == "/":
             raise errors.RemoveRootError()
         info = self.getinfo(path)
         if not info.is_dir:
@@ -184,7 +181,7 @@ class BlobFSV2(FS):
 
     def setinfo(self, path: str, info) -> None:
         self.check()
-        path = self._validatepath(path)
+        path = self.validatepath(path)
         if not self.exists(path):
             raise errors.ResourceNotFound(path)
         if DETAILS in info:

--- a/fs/azblob/helpers.py
+++ b/fs/azblob/helpers.py
@@ -1,0 +1,24 @@
+import datetime
+
+from fs.enums import ResourceType
+from fs.info import Info
+from fs.time import datetime_to_epoch
+
+from fs.azblob.const import BASIC, DETAILS, IS_DIR, TYPE
+
+
+def _convert_to_epoch(props: dict) -> None:
+    for k, v in props.items():
+        if isinstance(v, datetime.datetime):
+            props[k] = datetime_to_epoch(v)
+
+
+def _info_from_dict(info: dict, namespaces) -> Info:
+    if DETAILS in namespaces:
+        if DETAILS not in info:
+            info[DETAILS] = {}
+        if info[BASIC][IS_DIR]:
+            info[DETAILS][TYPE] = ResourceType.directory
+        else:
+            info[DETAILS][TYPE] = ResourceType.file
+    return Info(info)

--- a/fs/opener/blob_fs.py
+++ b/fs/opener/blob_fs.py
@@ -1,4 +1,4 @@
-__all__ = ["BlobFSOpener"]
+__all__ = ["BlobFSOpener", "BlobFSV2Opener"]
 
 from fs.azblob import BlobFS
 from fs.azblob.blob_fs_v2 import BlobFSV2

--- a/fs/opener/blob_fs.py
+++ b/fs/opener/blob_fs.py
@@ -1,6 +1,7 @@
 __all__ = ["BlobFSOpener"]
 
 from fs.azblob import BlobFS
+from fs.azblob.blob_fs_v2 import BlobFSV2
 from fs.opener import Opener
 from fs.opener.errors import OpenerError
 
@@ -23,3 +24,23 @@ class BlobFSOpener(Opener):
             account_key = None
 
         return BlobFS(account_name, container, account_key)
+
+
+class BlobFSV2Opener(Opener):
+    """Open url at azblobv2://<account_name>:<account_key>@<container>"""
+
+    protocols = ["azblobv2"]
+
+    def open_fs(self, fs_url, parse_result, writeable, create, cwd):
+        account_name = parse_result.username
+        account_key = parse_result.password
+        container = parse_result.resource
+
+        if account_name is None:
+            raise OpenerError("account_name is required")
+        if container is None:
+            raise OpenerError("container is required")
+        if account_key == "":
+            account_key = None
+
+        return BlobFSV2(account_name, container, account_key)

--- a/fs/opener/blob_fs.py
+++ b/fs/opener/blob_fs.py
@@ -6,24 +6,28 @@ from fs.opener import Opener
 from fs.opener.errors import OpenerError
 
 
+def open_fs(fs_class, parse_result):
+    account_name = parse_result.username
+    account_key = parse_result.password
+    container = parse_result.resource
+
+    if account_name is None:
+        raise OpenerError("account_name is required")
+    if container is None:
+        raise OpenerError("container is required")
+    if account_key == "":
+        account_key = None
+
+    return fs_class(account_name, container, account_key)
+
+
 class BlobFSOpener(Opener):
     """Open url at azblob://<account_name>:<account_key>@<container>"""
 
     protocols = ["azblob"]
 
     def open_fs(self, fs_url, parse_result, writeable, create, cwd):
-        account_name = parse_result.username
-        account_key = parse_result.password
-        container = parse_result.resource
-
-        if account_name is None:
-            raise OpenerError("account_name is required")
-        if container is None:
-            raise OpenerError("container is required")
-        if account_key == "":
-            account_key = None
-
-        return BlobFS(account_name, container, account_key)
+        return open_fs(BlobFS, parse_result)
 
 
 class BlobFSV2Opener(Opener):
@@ -32,15 +36,4 @@ class BlobFSV2Opener(Opener):
     protocols = ["azblobv2"]
 
     def open_fs(self, fs_url, parse_result, writeable, create, cwd):
-        account_name = parse_result.username
-        account_key = parse_result.password
-        container = parse_result.resource
-
-        if account_name is None:
-            raise OpenerError("account_name is required")
-        if container is None:
-            raise OpenerError("container is required")
-        if account_key == "":
-            account_key = None
-
-        return BlobFSV2(account_name, container, account_key)
+        return open_fs(BlobFSV2, parse_result)

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,11 +17,13 @@ packages = fs.azblob, fs.opener
 python_requires = >=3.8
 install_requires =
     fs~=2.4.13
-    azure-storage-blob~=12.8.1
+    azure-storage-blob
+    azure-storage-file-datalake
 
 [options.entry_points]
 fs.opener =
     azblob = fs.opener.blob_fs:BlobFSOpener
+    azblobv2 = fs.opener.blob_fs:BlobFSV2Opener
 
 [flake8]
 ignore = E501

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = fs-azureblob
-version = 0.1.0
+version = 0.2.0
 author = Breakthrough Energy
 author_email = sciences@breakthroughenergy.org
 description = Azure blob storage filesystem for PyFilesystem2

--- a/tests/test.py
+++ b/tests/test.py
@@ -4,7 +4,18 @@ import unittest
 import pytest
 from fs.test import FSTestCases
 
-from fs.azblob import BlobFS
+from fs.azblob import BlobFS, BlobFSV2
+
+
+@pytest.mark.creds
+class TestBlobFSV2(FSTestCases, unittest.TestCase):
+    def make_fs(self):
+        account_name = "esmi"
+        container = "test3"
+        key = os.getenv("BLOB_ACCOUNT_KEY_V2")
+        bfs = BlobFSV2(account_name, container, key)
+        bfs.removetree("/")
+        return bfs
 
 
 @pytest.mark.creds


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Implement the pyfilesystem api for storage accounts using a hierarchical namespace (which I'm referring to as gen2). There is a separate sdk, and although supposedly the feature is compatible with the sdk currently used, the fs implementation has logic to fake directories that isn't needed (and also doesn't work out of the box) for gen2. 

### What the code is doing
Implement a new `FS` subclass which acts as a wrapper around the `azure-storage-file-datalake` library to provide a consistent api. Note, there is duplication between the two classes (`BlobFS` and `BlobFSV2`), but given that this probably won't be generalized often and the differences are spread throughout the class, I didn't think it was worth trying to abstract out the common code. 

### Testing
Added a new test class that hooks into the base library test cases. All the tests pass for both filesystems. 

### Usage Example/Visuals
No changes other than the introduction of a new fs class. See readme for details.

### Time estimate
30 min? depends on how closely you want to look. The main criteria is that the tests pass (there are ~77 tests that are quite comprehensive, so I expect it's not easy to find a bug that isn't covered there). 
