### PR TITLE
fix: set read_only property so it doesn't default to True

### DIFF
--- a/fs/azblob/blob_fs.py
+++ b/fs/azblob/blob_fs.py
@@ -23,6 +23,7 @@ from fs.azblob.const import (
     METADATA_CHANGED,
     MODIFIED,
     NAME,
+    READ_ONLY,
     SIZE,
 )
 from fs.azblob.error_tools import blobfs_errors
@@ -45,6 +46,8 @@ class BlobFS(FS):
         )
         self._check_container_client()
         self._init()
+        self._meta = self._meta.copy()
+        self._meta[READ_ONLY] = account_key is None
 
     def _check_container_client(self):
         try:

--- a/fs/azblob/blob_fs_v2.py
+++ b/fs/azblob/blob_fs_v2.py
@@ -21,6 +21,7 @@ from fs.azblob.const import (
     METADATA_CHANGED,
     MODIFIED,
     NAME,
+    READ_ONLY,
     SIZE,
 )
 from fs.azblob.error_tools import blobfs_errors
@@ -51,6 +52,8 @@ class BlobFSV2(FS):
         )
         self.client = self._svc.get_file_system_client(container)
         self._check_container_client()
+        self._meta = self._meta.copy()
+        self._meta[READ_ONLY] = account_key is None
 
     def _check_container_client(self):
         try:

--- a/fs/azblob/const.py
+++ b/fs/azblob/const.py
@@ -28,3 +28,4 @@ def _build_invalid_chars():
 
 
 INVALID_CHARS = _build_invalid_chars()
+READ_ONLY = "read_only"


### PR DESCRIPTION
### Purpose
Fix some tests that were broken due to a recent update.

### What the code is doing
This [commit](https://github.com/PyFilesystem/pyfilesystem2/commit/ad7a970b) added an optimization that checks the `read_only` property of `FS._meta`, but defaults to `True` if it's not explicitly set. Apparently I hadn't run the tests since updating the base library in my local environment, so just now noticed the failures.

This fix isn't as precise as possible (that would involve validating the account key permissions somehow), but simply assumes the filesystem is writable unless no account key is provided at all. I'm not sure of a situation where this _doesn't_ work as expected,  but it's possible. 

### Testing
Reran the test suite (not part of `nox` by default) - `pytest tests/test.py`


### Time estimate
5 min
