### PR TITLE
perf: optimize move operation

### DIFF
--- a/fs/azblob/blob_fs_v2.py
+++ b/fs/azblob/blob_fs_v2.py
@@ -162,6 +162,28 @@ class BlobFSV2(FS):
             dir_client.create_directory()
         return SubFS(self, path)
 
+    def move(
+        self,
+        src_path: str,
+        dst_path: str,
+        overwrite: bool = False,
+        preserve_time: bool = False,
+    ) -> None:
+
+        self.check()
+        if not overwrite and self.exists(dst_path):
+            raise errors.DestinationExists(dst_path)
+        if self.isdir(src_path):
+            raise errors.FileExpected(src_path)
+
+        src_path = self.validatepath(src_path)
+        dst_path = self.validatepath(dst_path)
+
+        with blobfs_errors(src_path):
+            blob = self.client.get_file_client(src_path)
+            with blobfs_errors(dst_path):
+                blob.rename_file(self.client.file_system_name + dst_path)
+
     def remove(self, path: str) -> None:
         self.check()
         _path = self.validatepath(path)

--- a/fs/azblob/error_tools.py
+++ b/fs/azblob/error_tools.py
@@ -20,5 +20,7 @@ def blobfs_errors(path):
         raise errors.DestinationExists(path)
     except ResourceNotFoundError:
         raise errors.ResourceNotFound(path)
-    except:  # noqa
+    except Exception as e:
+        if isinstance(e, errors.FSError):
+            raise
         raise errors.FSError(traceback.format_exc())


### PR DESCRIPTION
### Purpose
Improve the performance of file renaming/moving by using the api to do so on the backend.

### What the code is doing
The default way is implemented in the base class using the [essential methods](https://docs.pyfilesystem.org/en/latest/implementers.html#essential-methods) which simplifies the requirement for implementing a filesystem. However, this means files will be downloaded and re-uploaded when calling `blob_fs.move(src, dst)`. We override that by using the `rename_file` method in the azure sdk, which presumably does this in constant time.


### Testing
Ran the test suite - `pytest tests/test.py`. To validate the perf improvement I just wrote a loop that creates and renames 10 files with a few MB of content each. The current way took 17sec vs about 1sec for the optimized version.


### Time estimate
5 min
