### PR TITLE
Fixes and updates for getinfo, setinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ using the following arguments:
 - `container`: the blob container
 - `account_key`: optional, but required for write operations or depending on the storage account access policies
 
+### Resource Info
+Users can call `getinfo` for the `basic` and `details` namespaces, however support for
+`setinfo` is limited, as these properties are enforced by azure (e.g. last modified
+time). There is a custom namespace called `blob` which can be used to set metadata on a
+blob, in the form of key value pairs which must be valid http headers.
+
+See [docs](https://docs.pyfilesystem.org/en/latest/info.html) for more details.
+
 ## Note
 The following can be ignored if using an account with hierarchical namespace.
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Users can call `getinfo` for the `basic` and `details` namespaces, however suppo
 time). There is a custom namespace called `blob` which can be used to set metadata on a
 blob, in the form of key value pairs which must be valid http headers.
 
+Additionally, the v2 filesystem for hierarchical namespaces supports posix permissions,
+so the `access` namespaces is supported for `getinfo` calls, which includes this
+information.
+
 See [docs](https://docs.pyfilesystem.org/en/latest/info.html) for more details.
 
 ## Note

--- a/fs/azblob/blob_fs_v2.py
+++ b/fs/azblob/blob_fs_v2.py
@@ -226,8 +226,8 @@ class BlobFSV2(FS):
         path = self.validatepath(path)
         if not self.exists(path):
             raise errors.ResourceNotFound(path)
-        if BLOB in info:
-            meta = info[BLOB]
-            with blobfs_errors(path):
-                blob = self.client.get_file_client(path)
-                blob.set_metadata(meta)
+        with blobfs_errors(path):
+            blob = self.client.get_file_client(path)
+            meta = blob.get_file_properties()[METADATA]
+            meta.update(info.get(BLOB, {}))
+            blob.set_metadata(meta)

--- a/fs/azblob/blob_fs_v2.py
+++ b/fs/azblob/blob_fs_v2.py
@@ -5,11 +5,13 @@ from fs.base import FS
 from fs.info import Info
 from fs.mode import Mode
 from fs.path import basename, dirname
+from fs.permissions import Permissions
 from fs.subfs import SubFS
 
 from fs import errors
 from fs.azblob.blob_file import BlobFile
 from fs.azblob.const import (
+    ACCESS,
     ACCESSED,
     BASIC,
     BLOB,
@@ -23,6 +25,7 @@ from fs.azblob.const import (
     METADATA_CHANGED,
     MODIFIED,
     NAME,
+    PERMISSIONS,
     READ_ONLY,
     SIZE,
 )
@@ -94,6 +97,15 @@ class BlobFSV2(FS):
 
         if BLOB in namespaces:
             info[BLOB] = props[METADATA]
+
+        if ACCESS in namespaces:
+            perms = blob.get_access_control()[PERMISSIONS]
+            info[ACCESS] = {
+                PERMISSIONS: Permissions(
+                    user=perms[:3], group=perms[3:6], other=perms[6:]
+                )
+            }
+
         return _info_from_dict(info, namespaces)
 
     def listdir(self, path: str) -> list:

--- a/fs/azblob/blob_fs_v2.py
+++ b/fs/azblob/blob_fs_v2.py
@@ -12,12 +12,14 @@ from fs.azblob.blob_file import BlobFile
 from fs.azblob.const import (
     ACCESSED,
     BASIC,
+    BLOB,
     CREATED,
     CREATION_TIME,
     DETAILS,
     INVALID_CHARS,
     IS_DIR,
     LAST_MODIFIED,
+    METADATA,
     METADATA_CHANGED,
     MODIFIED,
     NAME,
@@ -89,6 +91,9 @@ class BlobFSV2(FS):
             }
             _convert_to_epoch(details)
             info[DETAILS] = details
+
+        if BLOB in namespaces:
+            info[BLOB] = props[METADATA]
         return _info_from_dict(info, namespaces)
 
     def listdir(self, path: str) -> list:
@@ -209,12 +214,8 @@ class BlobFSV2(FS):
         path = self.validatepath(path)
         if not self.exists(path):
             raise errors.ResourceNotFound(path)
-        if DETAILS in info:
-            details = info[DETAILS]
-            meta = {
-                # TODO: custom metadata?
-                LAST_MODIFIED: str(details[MODIFIED]),
-            }
+        if BLOB in info:
+            meta = info[BLOB]
             with blobfs_errors(path):
                 blob = self.client.get_file_client(path)
                 blob.set_metadata(meta)

--- a/fs/azblob/const.py
+++ b/fs/azblob/const.py
@@ -2,9 +2,13 @@
 # directory is created/removed. It is excluded from list operations.
 DIR_ENTRY = ".fs_azblob"
 
-# getinfo keys
+# getinfo namespaces
 BASIC = "basic"
 DETAILS = "details"
+ACCESS = "access"
+BLOB = "blob"
+
+# getinfo keys
 TYPE = "type"
 IS_DIR = "is_dir"
 NAME = "name"
@@ -13,6 +17,7 @@ MODIFIED = "modified"
 CREATED = "created"
 METADATA_CHANGED = "metadata_changed"
 SIZE = "size"
+PERMISSIONS = "permissions"
 
 # property names from azure sdk
 LAST_ACCESSED_ON = "last_accessed_on"
@@ -30,6 +35,3 @@ def _build_invalid_chars():
 
 INVALID_CHARS = _build_invalid_chars()
 READ_ONLY = "read_only"
-
-# namespace for getinfo/setinfo
-BLOB = "blob"

--- a/fs/azblob/const.py
+++ b/fs/azblob/const.py
@@ -18,6 +18,7 @@ SIZE = "size"
 LAST_ACCESSED_ON = "last_accessed_on"
 CREATION_TIME = "creation_time"
 LAST_MODIFIED = "last_modified"
+METADATA = "metadata"
 
 
 def _build_invalid_chars():
@@ -29,3 +30,6 @@ def _build_invalid_chars():
 
 INVALID_CHARS = _build_invalid_chars()
 READ_ONLY = "read_only"
+
+# namespace for getinfo/setinfo
+BLOB = "blob"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = fs-azureblob
-version = 0.2.0
+version = 0.2.1
 author = Breakthrough Energy
 author_email = sciences@breakthroughenergy.org
 description = Azure blob storage filesystem for PyFilesystem2


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
I noticed that calls to `setinfo` via `touch` were not consistently updating the `last_modified` property as expected. This addresses that by making the behavior more intuitive. The version is updated so we can release a patch. 

### What the code is doing
Context: blobs have properties that are managed by azure, among which are `last_modified`, `creation_time`, etc. When we call `get_blob_properties` or `get_file_properties` we get these back, in addition to a `metadata: {...}` dict which contains values that a user can set. This makes sense, as a user shouldn't be able to modify access times, which provide audit integrity. 

So what we do is instead of using the `details` namespace, we define a new one called `blob` (similar to `s3fs` which has an `s3` namespace). This is how a user can update custom properties. Most importantly, within `setinfo`, we always make a call to update the values, even if just to replace the existing ones. This isn't enforced by the test suite, but I think it makes sense that any calls to this would be reflected in the last modified time (which is updated by azure automatically). 

For the v2 implementation we also add support for the `access` namespace, e.g. `bfs.getinfo(path, namespaces=["access"])` which returns an `Info` object with the file permissions.

These are all semi specific to this library, so I added docs to the readme.

### Testing
Manual testing to verify the behavior of `last_modified` given different inputs to `setinfo` and permissions related work. Ran the test suite for both v1 and v2 filesystems.

### Where to look
The official [docs](https://docs.pyfilesystem.org/en/latest/info.html) (linked in the readme) for resource info, for conceptual background.


### Time estimate
15 mins
